### PR TITLE
Swerve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,7 +174,7 @@ networktables.json.bck
 simgui-ds.json
 simgui.json
 *-window.json
-pid_constants.ini
+pid_constants.ini*
 
 # Simulation data log directory
 logs/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -73,5 +73,5 @@
   "editor.rulers": [120],
   "files.autoSave": "afterDelay",
   "files.autoSaveDelay": 1000,
-  "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m -Xlog:disable"
+  "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx4G -Xms100m -Xlog:disable"
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -5,6 +5,16 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class Constants {
+
+    public static final CANAddress SWERVE_TURN_LEFT_FRONT = new CANAddress(11);
+    public static final CANAddress SWERVE_TURN_LEFT_REAR = new CANAddress(13);
+    public static final CANAddress SWERVE_TURN_RIGHT_FRONT = new CANAddress(5);
+    public static final CANAddress SWERVE_TURN_RIGHT_REAR = new CANAddress(12);
+    public static final CANAddress SWERVE_DRIVE_LEFT_FRONT = new CANAddress(2);
+    public static final CANAddress SWERVE_DRIVE_LEFT_REAR = new CANAddress(3);
+    public static final CANAddress SWERVE_DRIVE_RIGHT_FRONT = new CANAddress(1);
+    public static final CANAddress SWERVE_DRIVE_RIGHT_REAR = new CANAddress(4);
+
     public static Path DATA_STORE_FILE;
 
     static {
@@ -14,6 +24,13 @@ public class Constants {
             DATA_STORE_FILE = Paths.get("./pid_constants.ini");
         }
     }
+
+    /**
+     * A wrapper class holding a single integer value representing a CAN Address. The point of this
+     * class is to indicate that the wrapped value is a CAN Address in a more robust way than just
+     * adding "CAN_ADDR" to the constant's name.
+     */
+    public static record CANAddress(int address) {}
 
     private Constants() {
         throw new UnsupportedOperationException("Constants is a static class");

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -15,6 +15,8 @@ public class Constants {
     public static final CANAddress SWERVE_DRIVE_RIGHT_FRONT = new CANAddress(1);
     public static final CANAddress SWERVE_DRIVE_RIGHT_REAR = new CANAddress(4);
 
+    public static final HIDPort XBOX_CONTROLLER_1 = new HIDPort(0);
+
     public static Path DATA_STORE_FILE;
 
     static {
@@ -31,6 +33,13 @@ public class Constants {
      * adding "CAN_ADDR" to the constant's name.
      */
     public static record CANAddress(int address) {}
+
+    /**
+     * A wrapper class holding a single integer value representing a HID Port. The point of this
+     * class is to indicate that the wrapped value is a HID Port in a more robust way than just
+     * adding "PORT" to the constant's name.
+     */
+    public static record HIDPort(int hidport) {}
 
     private Constants() {
         throw new UnsupportedOperationException("Constants is a static class");

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -1,0 +1,21 @@
+package frc.robot;
+
+import edu.wpi.first.wpilibj.RobotBase;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class Constants {
+    public static Path DATA_STORE_FILE;
+
+    static {
+        if (RobotBase.isReal()) {
+            DATA_STORE_FILE = Paths.get("/home/lvuser/pid_constants.ini");
+        } else {
+            DATA_STORE_FILE = Paths.get("./pid_constants.ini");
+        }
+    }
+
+    private Constants() {
+        throw new UnsupportedOperationException("Constants is a static class");
+    }
+}

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -4,6 +4,7 @@
 
 package frc.robot;
 
+import com.momentum4999.motune.PIDTuner;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
@@ -26,6 +27,8 @@ public class Robot extends TimedRobot {
     @Override
     public void robotPeriodic() {
         CommandScheduler.getInstance().run();
+
+        PIDTuner.pollAllStateValues();
     }
 
     @Override

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -7,6 +7,7 @@ package frc.robot;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import frc.robot.molib.prefs.MoPrefs;
 
 public class Robot extends TimedRobot {
     private Command m_autonomousCommand;
@@ -15,6 +16,11 @@ public class Robot extends TimedRobot {
 
     public Robot() {
         m_robotContainer = new RobotContainer();
+    }
+
+    @Override
+    public void robotInit() {
+        MoPrefs.cleanUpPrefs();
     }
 
     @Override

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -6,8 +6,12 @@ package frc.robot;
 
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
+import frc.robot.subsystem.DriveSubsystem;
 
 public class RobotContainer {
+
+    private DriveSubsystem drive = new DriveSubsystem();
+
     public RobotContainer() {
         configureBindings();
     }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,19 +4,30 @@
 
 package frc.robot;
 
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
+import frc.robot.input.ControllerInput;
+import frc.robot.input.MoInput;
 import frc.robot.subsystem.DriveSubsystem;
 
 public class RobotContainer {
 
     private DriveSubsystem drive = new DriveSubsystem();
 
+    private SendableChooser<MoInput> inputChooser = new SendableChooser<>();
+
     public RobotContainer() {
         configureBindings();
+
+        inputChooser.setDefaultOption("Single F310", new ControllerInput());
     }
 
     private void configureBindings() {}
+
+    private MoInput getInput() {
+        return inputChooser.getSelected();
+    }
 
     public Command getAutonomousCommand() {
         return Commands.print("No autonomous command configured");

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,16 +4,21 @@
 
 package frc.robot;
 
+import com.studica.frc.AHRS;
+import com.studica.frc.AHRS.NavXComType;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import frc.robot.input.ControllerInput;
 import frc.robot.input.MoInput;
 import frc.robot.subsystem.DriveSubsystem;
+import frc.robot.subsystem.PositioningSubsystem;
 
 public class RobotContainer {
+    private AHRS gyro = new AHRS(NavXComType.kMXP_UART);
 
     private DriveSubsystem drive = new DriveSubsystem();
+    private PositioningSubsystem positioning = new PositioningSubsystem(gyro);
 
     private SendableChooser<MoInput> inputChooser = new SendableChooser<>();
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -9,6 +9,7 @@ import com.studica.frc.AHRS.NavXComType;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
+import frc.robot.command.TeleopDriveCommand;
 import frc.robot.input.ControllerInput;
 import frc.robot.input.MoInput;
 import frc.robot.subsystem.DriveSubsystem;
@@ -20,12 +21,16 @@ public class RobotContainer {
     private DriveSubsystem drive = new DriveSubsystem();
     private PositioningSubsystem positioning = new PositioningSubsystem(gyro);
 
+    private TeleopDriveCommand driveCommand = new TeleopDriveCommand(drive, positioning, this::getInput);
+
     private SendableChooser<MoInput> inputChooser = new SendableChooser<>();
 
     public RobotContainer() {
         configureBindings();
 
         inputChooser.setDefaultOption("Single F310", new ControllerInput());
+
+        drive.setDefaultCommand(driveCommand);
     }
 
     private void configureBindings() {}

--- a/src/main/java/frc/robot/command/TeleopDriveCommand.java
+++ b/src/main/java/frc/robot/command/TeleopDriveCommand.java
@@ -1,0 +1,67 @@
+package frc.robot.command;
+
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.filter.SlewRateLimiter;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.input.MoInput;
+import frc.robot.molib.prefs.MoPrefs;
+import frc.robot.subsystem.DriveSubsystem;
+import frc.robot.subsystem.PositioningSubsystem;
+import frc.robot.utils.MoUtils;
+import frc.robot.utils.Vec2;
+import java.util.function.Supplier;
+
+public class TeleopDriveCommand extends Command {
+    private final DriveSubsystem drive;
+    private final PositioningSubsystem positioning;
+    private final Supplier<MoInput> inputSupplier;
+
+    private SlewRateLimiter translationLimiter;
+    private SlewRateLimiter rotationLimiter;
+
+    private Vec2 mutMoveRequest = new Vec2(0, 0);
+
+    public TeleopDriveCommand(DriveSubsystem drive, PositioningSubsystem positioning, Supplier<MoInput> inputSupplier) {
+        this.drive = drive;
+        this.positioning = positioning;
+        this.inputSupplier = inputSupplier;
+
+        MoPrefs.driveRampTime.subscribe(
+                rampTime -> {
+                    double slewRate = 1.0 / rampTime;
+
+                    translationLimiter = new SlewRateLimiter(slewRate);
+                    rotationLimiter = new SlewRateLimiter(slewRate);
+                },
+                true);
+
+        addRequirements(drive);
+    }
+
+    private double applyInputTransforms(double value) {
+        return MoUtils.curve(MathUtil.applyDeadband(value, MoPrefs.inputDeadzone.get()), MoPrefs.inputCurve.get());
+    }
+
+    @Override
+    public void execute() {
+        MoInput input = inputSupplier.get();
+
+        if (input.getReZeroGyro()) {
+            positioning.resetFieldOrientedFwd();
+        }
+
+        mutMoveRequest.update(input.getMoveRequest());
+        double norm = mutMoveRequest.normalize();
+        norm = applyInputTransforms(norm);
+        norm = translationLimiter.calculate(norm);
+        mutMoveRequest.scale(norm);
+
+        double turnRequest = input.getTurnRequest();
+        turnRequest = applyInputTransforms(turnRequest);
+
+        Rotation2d foHeading = positioning.getFieldOrientedDriveHeading();
+
+        drive.driveCartesian(mutMoveRequest.getY(), mutMoveRequest.getX(), turnRequest, foHeading);
+    }
+}

--- a/src/main/java/frc/robot/component/SwerveModule.java
+++ b/src/main/java/frc/robot/component/SwerveModule.java
@@ -1,0 +1,164 @@
+package frc.robot.component;
+
+import com.ctre.phoenix6.controls.DutyCycleOut;
+import com.ctre.phoenix6.hardware.TalonFX;
+import com.ctre.phoenix6.signals.NeutralModeValue;
+import com.revrobotics.spark.ClosedLoopSlot;
+import com.revrobotics.spark.SparkBase.PersistMode;
+import com.revrobotics.spark.SparkBase.ResetMode;
+import com.revrobotics.spark.SparkMax;
+import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
+import com.revrobotics.spark.config.SparkMaxConfig;
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.kinematics.SwerveModulePosition;
+import edu.wpi.first.math.kinematics.SwerveModuleState;
+import edu.wpi.first.units.AngleUnit;
+import edu.wpi.first.units.AngularVelocityUnit;
+import edu.wpi.first.units.DimensionlessUnit;
+import edu.wpi.first.units.DistanceUnit;
+import edu.wpi.first.units.LinearVelocityUnit;
+import edu.wpi.first.units.Measure;
+import edu.wpi.first.units.PerUnit;
+import edu.wpi.first.units.Units;
+import edu.wpi.first.units.measure.MutAngle;
+import edu.wpi.first.units.measure.MutLinearVelocity;
+import frc.robot.molib.MoUnits;
+import frc.robot.molib.encoder.MoDistanceEncoder;
+import frc.robot.molib.encoder.MoRotationEncoder;
+import frc.robot.molib.pid.MoSparkMaxPID;
+import frc.robot.molib.pid.MoTalonFxPID;
+import frc.robot.molib.prefs.UnitPref;
+import frc.robot.utils.TunerUtils;
+
+public class SwerveModule {
+    // The Thrifty absolute magnetic encoder outputs a voltage between 0-5v throughout 1 rotation, but it's scaled
+    // down to 1-3.3v by the SparkMax data port breakout board. Thus, when the mechanism travels 1 rotation, the
+    // absolute encoder will travel through 3.3 "Encoder Ticks" (which happen to correspond to volts).
+    private static final Measure<PerUnit<DimensionlessUnit, AngleUnit>> ABSOLUTE_ENCODER_SCALE =
+            MoUnits.EncoderTicksPerRotation.ofNative(3.3);
+
+    private static final double MOTOR_UNPOWERED_SPEED = 0.05;
+
+    private final String key;
+    public final SparkMax turnMotor;
+    public final TalonFX driveMotor;
+
+    public final MoRotationEncoder absoluteEncoder;
+    public final MoRotationEncoder relativeEncoder;
+
+    public final MoDistanceEncoder distEncoder;
+
+    public final MoSparkMaxPID<AngleUnit, AngularVelocityUnit> turnPID;
+    private final MoTalonFxPID<DistanceUnit, LinearVelocityUnit> drivePID;
+
+    private final UnitPref<AngleUnit> encoderZero;
+    private final UnitPref<PerUnit<DimensionlessUnit, AngleUnit>> encoderRotScale;
+
+    private final MutAngle mut_angleSetpoint = Units.Rotations.mutable(0);
+    private final MutLinearVelocity mut_velocitySetpoint = Units.MetersPerSecond.mutable(0);
+
+    public SwerveModule(
+            String key,
+            SparkMax turnMotor,
+            TalonFX driveMotor,
+            UnitPref<AngleUnit> encoderZero,
+            UnitPref<PerUnit<DimensionlessUnit, AngleUnit>> encoderRotScale,
+            UnitPref<PerUnit<DimensionlessUnit, DistanceUnit>> encoderDistScale) {
+        this.key = key;
+        this.turnMotor = turnMotor;
+        this.driveMotor = driveMotor;
+        this.encoderZero = encoderZero;
+        this.encoderRotScale = encoderRotScale;
+
+        SparkMaxConfig sparkConfig = new SparkMaxConfig();
+
+        this.driveMotor.setNeutralMode(NeutralModeValue.Brake);
+        sparkConfig.idleMode(IdleMode.kBrake);
+
+        this.absoluteEncoder = MoRotationEncoder.forSparkAnalog(turnMotor, Units.Rotations);
+        this.absoluteEncoder.setConversionFactor(ABSOLUTE_ENCODER_SCALE);
+
+        relativeEncoder = MoRotationEncoder.forSparkRelative(turnMotor, Units.Radians);
+
+        distEncoder = MoDistanceEncoder.forTalonFx(driveMotor, Units.Meters);
+        encoderDistScale.subscribe(scale -> distEncoder.setConversionFactor(scale), true);
+
+        this.turnPID =
+                new MoSparkMaxPID<>(MoSparkMaxPID.Type.POSITION, turnMotor, ClosedLoopSlot.kSlot0, relativeEncoder);
+        this.drivePID =
+                new MoTalonFxPID<>(MoTalonFxPID.Type.VELOCITY, driveMotor, distEncoder.getInternalEncoderUnits());
+
+        sparkConfig.closedLoop.positionWrappingInputRange(-Math.PI, Math.PI).positionWrappingEnabled(true);
+
+        TunerUtils.forMoSparkMax(turnPID, key + "_turn");
+        TunerUtils.forMoTalonFx(drivePID, key + "_drive");
+
+        encoderZero.subscribe(
+                zero -> this.setupRelativeEncoder(absoluteEncoder.getPosition(), zero, encoderRotScale.get()));
+        encoderRotScale.subscribe(
+                scale -> this.setupRelativeEncoder(absoluteEncoder.getPosition(), encoderZero.get(), scale));
+        setupRelativeEncoder();
+
+        turnMotor.configure(sparkConfig, ResetMode.kNoResetSafeParameters, PersistMode.kNoPersistParameters);
+    }
+
+    private boolean areMotorsPowered() {
+        return Math.abs(driveMotor.get()) > MOTOR_UNPOWERED_SPEED && Math.abs(turnMotor.get()) > MOTOR_UNPOWERED_SPEED;
+    }
+
+    public void setupRelativeEncoder() {
+        setupRelativeEncoder(absoluteEncoder.getPosition(), encoderZero.get(), encoderRotScale.get());
+    }
+
+    public void setRelativePosition() {
+        if (!areMotorsPowered()) {
+            setRelativePosition(absoluteEncoder.getPosition(), encoderZero.get());
+        }
+    }
+
+    private void setupRelativeEncoder(
+            Measure<AngleUnit> absPos,
+            Measure<AngleUnit> absZero,
+            Measure<PerUnit<DimensionlessUnit, AngleUnit>> scale) {
+        relativeEncoder.setConversionFactor(scale);
+        setRelativePosition(absPos, absZero);
+    }
+
+    private void setRelativePosition(Measure<AngleUnit> absPos, Measure<AngleUnit> absZero) {
+        double rots = absPos.in(Units.Rotations);
+        rots = (rots + 1 - absZero.in(Units.Rotations)) % 1;
+        relativeEncoder.setPosition(Units.Rotations.of(rots));
+    }
+
+    public void drive(SwerveModuleState state) {
+        state.optimize(new Rotation2d(relativeEncoder.getPosition()));
+        turnPID.setPositionReference(
+                mut_angleSetpoint.mut_replace(MathUtil.angleModulus(state.angle.getRadians()), Units.Radians));
+
+        drivePID.setVelocityReference(
+                mut_velocitySetpoint.mut_replace(state.speedMetersPerSecond, Units.MetersPerSecond));
+    }
+
+    public void directDrive(double turnSpeed, double driveSpeed) {
+        turnMotor.set(turnSpeed);
+        driveMotor.setControl(new DutyCycleOut(driveSpeed));
+    }
+
+    public SwerveModulePosition getPosition() {
+        return new SwerveModulePosition(distEncoder.getPosition(), new Rotation2d(relativeEncoder.getPosition()));
+    }
+
+    public SwerveModuleState getState() {
+        return new SwerveModuleState(distEncoder.getVelocity(), new Rotation2d(relativeEncoder.getPosition()));
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("SwerveModule(key=\"%s\")", this.key);
+    }
+}

--- a/src/main/java/frc/robot/input/ControllerInput.java
+++ b/src/main/java/frc/robot/input/ControllerInput.java
@@ -1,0 +1,28 @@
+package frc.robot.input;
+
+import edu.wpi.first.wpilibj.XboxController;
+import frc.robot.Constants;
+import frc.robot.utils.Vec2;
+
+public class ControllerInput implements MoInput {
+
+    private XboxController controller = new XboxController(Constants.XBOX_CONTROLLER_1.hidport());
+
+    private Vec2 moveRequest = new Vec2(0, 0);
+
+    @Override
+    public Vec2 getMoveRequest() {
+        moveRequest.update(controller.getLeftX(), controller.getLeftY());
+        return moveRequest;
+    }
+
+    @Override
+    public double getTurnRequest() {
+        return -1 * controller.getRightX();
+    }
+
+    @Override
+    public boolean getReZeroGyro() {
+        return controller.getBackButtonPressed();
+    }
+}

--- a/src/main/java/frc/robot/input/MoInput.java
+++ b/src/main/java/frc/robot/input/MoInput.java
@@ -1,0 +1,11 @@
+package frc.robot.input;
+
+import frc.robot.utils.Vec2;
+
+public interface MoInput {
+    public abstract Vec2 getMoveRequest();
+
+    public abstract double getTurnRequest();
+
+    public abstract boolean getReZeroGyro();
+}

--- a/src/main/java/frc/robot/molib/MoShuffleboard.java
+++ b/src/main/java/frc/robot/molib/MoShuffleboard.java
@@ -1,0 +1,45 @@
+package frc.robot.molib;
+
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
+import java.util.Optional;
+
+public class MoShuffleboard {
+    private static Optional<MoShuffleboard> instance = Optional.empty();
+
+    public static synchronized Optional<MoShuffleboard> getInstance() {
+        if (instance.isEmpty()) {
+            try {
+                instance = Optional.of(new MoShuffleboard());
+            } catch (IllegalArgumentException e) {
+                DriverStation.reportError("Failed to initialize MoShuffleboard", e.getStackTrace());
+            }
+        }
+
+        return instance;
+    }
+
+    public final ShuffleboardTab driveTab;
+
+    private MoShuffleboard() {
+        driveTab = Shuffleboard.getTab("Drive");
+    }
+
+    public static <T extends Enum<?>> SendableChooser<T> enumToChooser(Class<T> toConvert) {
+        boolean setDefault = true;
+        var chooser = new SendableChooser<T>();
+
+        for (T entry : toConvert.getEnumConstants()) {
+            if (setDefault) {
+                chooser.setDefaultOption(entry.name(), entry);
+                setDefault = false;
+            } else {
+                chooser.addOption(entry.name(), entry);
+            }
+        }
+
+        return chooser;
+    }
+}

--- a/src/main/java/frc/robot/molib/MoUnits.java
+++ b/src/main/java/frc/robot/molib/MoUnits.java
@@ -1,0 +1,25 @@
+package frc.robot.molib;
+
+import edu.wpi.first.units.AngleUnit;
+import edu.wpi.first.units.DimensionlessUnit;
+import edu.wpi.first.units.DistanceUnit;
+import edu.wpi.first.units.PerUnit;
+import edu.wpi.first.units.Units;
+
+public class MoUnits {
+    private MoUnits() {
+        throw new UnsupportedOperationException("Cannot instantiate MoUnits");
+    }
+
+    public static DimensionlessUnit EncoderTicks = Units.derive(Units.Value)
+            .aggregate(1)
+            .named("EncoderTicks")
+            .symbol("et")
+            .make();
+
+    public static PerUnit<DimensionlessUnit, DistanceUnit> EncoderTicksPerMeter = EncoderTicks.per(Units.Meter);
+    public static PerUnit<DimensionlessUnit, DistanceUnit> EncoderTicksPerCentimeter =
+            EncoderTicks.per(Units.Centimeter);
+    public static PerUnit<DimensionlessUnit, AngleUnit> EncoderTicksPerRotation = EncoderTicks.per(Units.Rotation);
+    public static PerUnit<DimensionlessUnit, AngleUnit> EncoderTicksPerRadian = EncoderTicks.per(Units.Radian);
+}

--- a/src/main/java/frc/robot/molib/encoder/MoDistanceEncoder.java
+++ b/src/main/java/frc/robot/molib/encoder/MoDistanceEncoder.java
@@ -1,0 +1,40 @@
+package frc.robot.molib.encoder;
+
+import com.ctre.phoenix6.hardware.TalonFX;
+import com.revrobotics.spark.SparkBase;
+import edu.wpi.first.units.DistanceUnit;
+import edu.wpi.first.units.LinearVelocityUnit;
+import edu.wpi.first.units.measure.Distance;
+import edu.wpi.first.units.measure.LinearVelocity;
+
+public class MoDistanceEncoder extends MoEncoder<DistanceUnit, LinearVelocityUnit> {
+    MoDistanceEncoder(Encoder encoder, DistanceUnit internalEncoderUnits) {
+        super(encoder, internalEncoderUnits);
+    }
+
+    @Override
+    public Distance getPosition() {
+        return (Distance) super.getPosition();
+    }
+
+    @Override
+    public LinearVelocity getVelocity() {
+        return (LinearVelocity) super.getVelocity();
+    }
+
+    public static MoDistanceEncoder forSparkRelative(SparkBase spark, DistanceUnit internalEncoderUnits) {
+        return new MoDistanceEncoder(new RevRelativeEncoder(spark), internalEncoderUnits);
+    }
+
+    public static MoDistanceEncoder forSparkAbsolute(SparkBase spark, DistanceUnit internalEncoderUnits) {
+        return new MoDistanceEncoder(new RevAbsoluteEncoder(spark), internalEncoderUnits);
+    }
+
+    public static MoDistanceEncoder forSparkAnalog(SparkBase spark, DistanceUnit internalEncoderUnits) {
+        return new MoDistanceEncoder(new RevAnalogSensorEncoder(spark), internalEncoderUnits);
+    }
+
+    public static MoDistanceEncoder forTalonFx(TalonFX talon, DistanceUnit internalEncoderUnits) {
+        return new MoDistanceEncoder(new TalonFxEncoder(talon), internalEncoderUnits);
+    }
+}

--- a/src/main/java/frc/robot/molib/encoder/MoEncoder.java
+++ b/src/main/java/frc/robot/molib/encoder/MoEncoder.java
@@ -1,0 +1,140 @@
+package frc.robot.molib.encoder;
+
+import com.ctre.phoenix6.hardware.TalonFX;
+import com.revrobotics.spark.SparkBase;
+import edu.wpi.first.units.DimensionlessUnit;
+import edu.wpi.first.units.Measure;
+import edu.wpi.first.units.MutableMeasure;
+import edu.wpi.first.units.PerUnit;
+import edu.wpi.first.units.TimeUnit;
+import edu.wpi.first.units.Unit;
+import frc.robot.molib.MoUnits;
+
+/**
+ * Wraps an encoder, keeping track of the encoder's internal units.
+ */
+public class MoEncoder<Dim extends Unit, VDim extends PerUnit<Dim, TimeUnit>> {
+    public static interface Encoder {
+        public double getPosition();
+
+        public void setPosition(double position);
+
+        public double getVelocity();
+
+        public void setInverted(boolean inverted);
+
+        /**
+         * Set the factor used internally by the encoder to scale encoder ticks to the desired output units.
+         * <p>
+         * Note: the factor is in units of internalEncoderUnits / encoder_tick.
+         * @param factor The factor to be internally multiplied by encoder ticks.
+         */
+        public void setPositionFactor(double factor);
+
+        /**
+         * Velocity is measured in distance per time. However, the dividing time unit is different across different
+         * encoders. For example, CTRE returns velocity in units of internalEncoderUnits per *second*, but
+         * Rev returns velocity in units of internalEncoderUnits per *minute*. So, for a CTRE encoder this method
+         * would return Units.Second, but for a Rev encoder this method would return Units.Minute.
+         * @return The base time unit of the velocity returned by this encoder.
+         */
+        public TimeUnit getVelocityBaseUnit();
+    }
+
+    private final Encoder encoder;
+
+    /**
+     * The units of the value returned by encoder.getPosition(), assuming the encoder has internally applied the set
+     * position factor.
+     */
+    private final Dim internalEncoderUnits;
+
+    /*
+     * The units of the value returned by encoder.getVelocity(), assuming the encoder has internally applied the set
+     * position factor.
+     */
+    private final VDim internalEncoderVelocityUnits;
+
+    private final MutableMeasure<Dim, ?, ?> mut_pos;
+    private final MutableMeasure<VDim, ?, ?> mut_vel;
+
+    @SuppressWarnings("unchecked")
+    MoEncoder(Encoder encoder, Dim internalEncoderUnits) {
+        this.encoder = encoder;
+        this.internalEncoderUnits = internalEncoderUnits;
+        this.internalEncoderVelocityUnits = (VDim) internalEncoderUnits.per(encoder.getVelocityBaseUnit());
+
+        mut_pos = (MutableMeasure<Dim, ?, ?>) internalEncoderUnits.mutable(0);
+        mut_vel = (MutableMeasure<VDim, ?, ?>) internalEncoderVelocityUnits.mutable(0);
+    }
+
+    public Dim getInternalEncoderUnits() {
+        return internalEncoderUnits;
+    }
+
+    public VDim getInternalEncoderVelocityUnits() {
+        return internalEncoderVelocityUnits;
+    }
+
+    public Encoder getEncoder() {
+        return encoder;
+    }
+
+    public void setConversionFactor(Measure<PerUnit<DimensionlessUnit, Dim>> mechanismConversionFactor) {
+        /*
+             * We need to set the position factor such that, when we call getPosition(), the value returned is in the
+        desired
+             * units as specified by internalEncoderUnits. We can model the internal encoder calculation as such:
+             * [ p encoder_ticks ] * [pos_factor internalEncoderUnits / encoder_ticks] = [p internalEncoderUnits]
+             * So, to get the output of the encoder in units of internalEncoderUnits, we need to calculate the pos_factor
+             * in units of internalEncoderUnits per encoder_ticks, then set that as the positionConversionFactor.
+             */
+        double positionFactor = 1 / mechanismConversionFactor.in(MoUnits.EncoderTicks.per(internalEncoderUnits));
+
+        encoder.setPositionFactor(positionFactor);
+    }
+
+    public Measure<Dim> getPosition() {
+        return mut_pos.mut_replace(encoder.getPosition(), internalEncoderUnits);
+    }
+
+    public void setPosition(Measure<Dim> position) {
+        encoder.setPosition(position.in(internalEncoderUnits));
+    }
+
+    public Measure<VDim> getVelocity() {
+        return mut_vel.mut_replace(encoder.getVelocity(), internalEncoderVelocityUnits);
+    }
+
+    public double getPositionInEncoderUnits() {
+        return getPosition().in(internalEncoderUnits);
+    }
+
+    public double getVelocityInEncoderUnits() {
+        return getVelocity().in(internalEncoderVelocityUnits);
+    }
+
+    public void setInverted(boolean inverted) {
+        encoder.setInverted(inverted);
+    }
+
+    public static <Dim extends Unit, VDim extends PerUnit<Dim, TimeUnit>> MoEncoder<Dim, VDim> forSparkRelative(
+            SparkBase spark, Dim internalEncoderUnits) {
+        return new MoEncoder<Dim, VDim>(new RevRelativeEncoder(spark), internalEncoderUnits);
+    }
+
+    public static <Dim extends Unit, VDim extends PerUnit<Dim, TimeUnit>> MoEncoder<Dim, VDim> forSparkAbsolute(
+            SparkBase spark, Dim internalEncoderUnits) {
+        return new MoEncoder<Dim, VDim>(new RevAbsoluteEncoder(spark), internalEncoderUnits);
+    }
+
+    public static <Dim extends Unit, VDim extends PerUnit<Dim, TimeUnit>> MoEncoder<Dim, VDim> forSparkAnalog(
+            SparkBase spark, Dim internalEncoderUnits) {
+        return new MoEncoder<Dim, VDim>(new RevAnalogSensorEncoder(spark), internalEncoderUnits);
+    }
+
+    public static <Dim extends Unit, VDim extends PerUnit<Dim, TimeUnit>> MoEncoder<Dim, VDim> forTalonFx(
+            TalonFX talon, Dim internalEncoderUnits) {
+        return new MoEncoder<Dim, VDim>(new TalonFxEncoder(talon), internalEncoderUnits);
+    }
+}

--- a/src/main/java/frc/robot/molib/encoder/MoRotationEncoder.java
+++ b/src/main/java/frc/robot/molib/encoder/MoRotationEncoder.java
@@ -1,0 +1,40 @@
+package frc.robot.molib.encoder;
+
+import com.ctre.phoenix6.hardware.TalonFX;
+import com.revrobotics.spark.SparkBase;
+import edu.wpi.first.units.AngleUnit;
+import edu.wpi.first.units.AngularVelocityUnit;
+import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularVelocity;
+
+public class MoRotationEncoder extends MoEncoder<AngleUnit, AngularVelocityUnit> {
+    MoRotationEncoder(Encoder encoder, AngleUnit internalEncoderUnits) {
+        super(encoder, internalEncoderUnits);
+    }
+
+    @Override
+    public Angle getPosition() {
+        return (Angle) super.getPosition();
+    }
+
+    @Override
+    public AngularVelocity getVelocity() {
+        return (AngularVelocity) super.getVelocity();
+    }
+
+    public static MoRotationEncoder forSparkRelative(SparkBase spark, AngleUnit internalEncoderUnits) {
+        return new MoRotationEncoder(new RevRelativeEncoder(spark), internalEncoderUnits);
+    }
+
+    public static MoRotationEncoder forSparkAbsolute(SparkBase spark, AngleUnit internalEncoderUnits) {
+        return new MoRotationEncoder(new RevAbsoluteEncoder(spark), internalEncoderUnits);
+    }
+
+    public static MoRotationEncoder forSparkAnalog(SparkBase spark, AngleUnit internalEncoderUnits) {
+        return new MoRotationEncoder(new RevAnalogSensorEncoder(spark), internalEncoderUnits);
+    }
+
+    public static MoRotationEncoder forTalonFx(TalonFX talon, AngleUnit internalEncoderUnits) {
+        return new MoRotationEncoder(new TalonFxEncoder(talon), internalEncoderUnits);
+    }
+}

--- a/src/main/java/frc/robot/molib/encoder/RevAbsoluteEncoder.java
+++ b/src/main/java/frc/robot/molib/encoder/RevAbsoluteEncoder.java
@@ -1,0 +1,58 @@
+package frc.robot.molib.encoder;
+
+import com.revrobotics.AbsoluteEncoder;
+import com.revrobotics.spark.SparkBase;
+import com.revrobotics.spark.SparkBase.PersistMode;
+import com.revrobotics.spark.SparkBase.ResetMode;
+import com.revrobotics.spark.config.SparkBaseConfig;
+import edu.wpi.first.units.TimeUnit;
+import edu.wpi.first.units.Units;
+import frc.robot.utils.MoUtils;
+
+public class RevAbsoluteEncoder implements MoEncoder.Encoder {
+    public static TimeUnit VELOCITY_BASE_UNIT = Units.Seconds;
+
+    private SparkBase spark;
+    private AbsoluteEncoder encoder;
+
+    public RevAbsoluteEncoder(SparkBase spark) {
+        this.spark = spark;
+        this.encoder = spark.getAbsoluteEncoder();
+
+        setPositionFactor(1);
+    }
+
+    @Override
+    public double getPosition() {
+        return encoder.getPosition();
+    }
+
+    @Override
+    public void setPosition(double position) {
+        throw new UnsupportedOperationException("Cannot set position on an absolute encoder");
+    }
+
+    @Override
+    public double getVelocity() {
+        return encoder.getVelocity();
+    }
+
+    @Override
+    public void setPositionFactor(double factor) {
+        SparkBaseConfig config = MoUtils.getSparkConfig(spark);
+        config.absoluteEncoder.positionConversionFactor(factor).velocityConversionFactor(factor);
+        spark.configure(config, ResetMode.kNoResetSafeParameters, PersistMode.kNoPersistParameters);
+    }
+
+    @Override
+    public TimeUnit getVelocityBaseUnit() {
+        return VELOCITY_BASE_UNIT;
+    }
+
+    @Override
+    public void setInverted(boolean inverted) {
+        SparkBaseConfig config = MoUtils.getSparkConfig(spark);
+        config.inverted(inverted);
+        spark.configure(config, ResetMode.kNoResetSafeParameters, PersistMode.kNoPersistParameters);
+    }
+}

--- a/src/main/java/frc/robot/molib/encoder/RevAnalogSensorEncoder.java
+++ b/src/main/java/frc/robot/molib/encoder/RevAnalogSensorEncoder.java
@@ -1,0 +1,60 @@
+package frc.robot.molib.encoder;
+
+import com.revrobotics.spark.SparkAnalogSensor;
+import com.revrobotics.spark.SparkBase;
+import com.revrobotics.spark.SparkBase.PersistMode;
+import com.revrobotics.spark.SparkBase.ResetMode;
+import com.revrobotics.spark.config.SparkBaseConfig;
+import edu.wpi.first.units.TimeUnit;
+import edu.wpi.first.units.Units;
+import frc.robot.utils.MoUtils;
+
+public class RevAnalogSensorEncoder implements MoEncoder.Encoder {
+    public static TimeUnit VELOCITY_BASE_UNIT = Units.Seconds;
+
+    private SparkBase spark;
+    private SparkAnalogSensor sensor;
+
+    public RevAnalogSensorEncoder(SparkBase spark) {
+        this.spark = spark;
+        this.sensor = spark.getAnalog();
+
+        this.setPositionFactor(1);
+    }
+
+    @Override
+    public double getPosition() {
+        return sensor.getPosition();
+    }
+
+    @Override
+    public void setPosition(double position) {
+        throw new UnsupportedOperationException("Cannot set position on an absolute encoder");
+    }
+
+    @Override
+    public double getVelocity() {
+        return sensor.getVelocity();
+    }
+
+    @Override
+    public void setPositionFactor(double factor) {
+        SparkBaseConfig config = MoUtils.getSparkConfig(spark);
+        config.analogSensor.positionConversionFactor(factor).velocityConversionFactor(factor);
+        spark.configure(config, ResetMode.kNoResetSafeParameters, PersistMode.kNoPersistParameters);
+    }
+
+    @Override
+    public TimeUnit getVelocityBaseUnit() {
+        return VELOCITY_BASE_UNIT;
+    }
+
+    @Override
+    public void setInverted(boolean inverted) {
+        SparkBaseConfig config = MoUtils.getSparkConfig(spark);
+
+        config.analogSensor.inverted(inverted);
+
+        spark.configure(config, ResetMode.kNoResetSafeParameters, PersistMode.kNoPersistParameters);
+    }
+}

--- a/src/main/java/frc/robot/molib/encoder/RevRelativeEncoder.java
+++ b/src/main/java/frc/robot/molib/encoder/RevRelativeEncoder.java
@@ -1,0 +1,58 @@
+package frc.robot.molib.encoder;
+
+import com.revrobotics.RelativeEncoder;
+import com.revrobotics.spark.SparkBase;
+import com.revrobotics.spark.SparkBase.PersistMode;
+import com.revrobotics.spark.SparkBase.ResetMode;
+import com.revrobotics.spark.config.SparkBaseConfig;
+import edu.wpi.first.units.TimeUnit;
+import edu.wpi.first.units.Units;
+import frc.robot.utils.MoUtils;
+
+public class RevRelativeEncoder implements MoEncoder.Encoder {
+    public static final TimeUnit VELOCITY_BASE_UNIT = Units.Minute;
+
+    private SparkBase spark;
+    private RelativeEncoder encoder;
+
+    public RevRelativeEncoder(SparkBase spark) {
+        this.spark = spark;
+        this.encoder = spark.getEncoder();
+
+        this.setPositionFactor(1);
+    }
+
+    @Override
+    public double getPosition() {
+        return encoder.getPosition();
+    }
+
+    @Override
+    public void setPosition(double position) {
+        encoder.setPosition(position);
+    }
+
+    @Override
+    public double getVelocity() {
+        return encoder.getVelocity();
+    }
+
+    @Override
+    public void setPositionFactor(double factor) {
+        SparkBaseConfig config = MoUtils.getSparkConfig(spark);
+        config.encoder.positionConversionFactor(factor).velocityConversionFactor(factor);
+        spark.configure(config, ResetMode.kNoResetSafeParameters, PersistMode.kNoPersistParameters);
+    }
+
+    @Override
+    public TimeUnit getVelocityBaseUnit() {
+        return VELOCITY_BASE_UNIT;
+    }
+
+    @Override
+    public void setInverted(boolean inverted) {
+        SparkBaseConfig config = MoUtils.getSparkConfig(spark);
+        config.encoder.inverted(inverted);
+        spark.configure(config, ResetMode.kNoResetSafeParameters, PersistMode.kNoPersistParameters);
+    }
+}

--- a/src/main/java/frc/robot/molib/encoder/TalonFxEncoder.java
+++ b/src/main/java/frc/robot/molib/encoder/TalonFxEncoder.java
@@ -1,0 +1,55 @@
+package frc.robot.molib.encoder;
+
+import com.ctre.phoenix6.configs.FeedbackConfigs;
+import com.ctre.phoenix6.hardware.TalonFX;
+import edu.wpi.first.units.TimeUnit;
+import edu.wpi.first.units.Units;
+
+public class TalonFxEncoder implements MoEncoder.Encoder {
+    public static final TimeUnit VELOCITY_BASE_UNIT = Units.Seconds;
+
+    private final TalonFX talon;
+
+    private boolean inverted = false;
+    private double lastSetPosFactor = 0;
+
+    public TalonFxEncoder(TalonFX talon) {
+        talon.getConfigurator()
+                .apply(new FeedbackConfigs().withRotorToSensorRatio(1).withSensorToMechanismRatio(1));
+        this.talon = talon;
+    }
+
+    @Override
+    public double getPosition() {
+        return talon.getPosition().getValueAsDouble();
+    }
+
+    @Override
+    public void setPosition(double position) {
+        talon.setPosition(position);
+    }
+
+    @Override
+    public double getVelocity() {
+        return talon.getVelocity().getValueAsDouble();
+    }
+
+    @Override
+    public void setPositionFactor(double factor) {
+        lastSetPosFactor = factor;
+        double dir = this.inverted ? -1 : 1;
+        talon.getConfigurator().apply(new FeedbackConfigs().withSensorToMechanismRatio(1 / (dir * lastSetPosFactor)));
+    }
+
+    @Override
+    public TimeUnit getVelocityBaseUnit() {
+        return VELOCITY_BASE_UNIT;
+    }
+
+    @Override
+    public void setInverted(boolean inverted) {
+        this.inverted = inverted;
+        double dir = this.inverted ? -1 : 1;
+        talon.getConfigurator().apply(new FeedbackConfigs().withSensorToMechanismRatio(1 / (dir * lastSetPosFactor)));
+    }
+}

--- a/src/main/java/frc/robot/molib/pid/MoSparkMaxPID.java
+++ b/src/main/java/frc/robot/molib/pid/MoSparkMaxPID.java
@@ -12,6 +12,7 @@ import edu.wpi.first.units.TimeUnit;
 import edu.wpi.first.units.Unit;
 import frc.robot.molib.encoder.MoEncoder;
 import frc.robot.utils.MoUtils;
+import java.util.function.Consumer;
 
 public class MoSparkMaxPID<Dim extends Unit, VDim extends PerUnit<Dim, TimeUnit>> {
     protected final Type type;
@@ -82,6 +83,12 @@ public class MoSparkMaxPID<Dim extends Unit, VDim extends PerUnit<Dim, TimeUnit>
     public void setIZone(double iZone) {
         SparkBaseConfig config = MoUtils.getSparkConfig(motorController);
         config.closedLoop.iZone(iZone, pidSlot);
+        motorController.configure(config, ResetMode.kNoResetSafeParameters, PersistMode.kNoPersistParameters);
+    }
+
+    public void setConfigOption(Consumer<SparkBaseConfig> op) {
+        SparkBaseConfig config = MoUtils.getSparkConfig(motorController);
+        op.accept(config);
         motorController.configure(config, ResetMode.kNoResetSafeParameters, PersistMode.kNoPersistParameters);
     }
 

--- a/src/main/java/frc/robot/molib/pid/MoSparkMaxPID.java
+++ b/src/main/java/frc/robot/molib/pid/MoSparkMaxPID.java
@@ -1,0 +1,150 @@
+package frc.robot.molib.pid;
+
+import com.revrobotics.spark.ClosedLoopSlot;
+import com.revrobotics.spark.SparkBase;
+import com.revrobotics.spark.SparkBase.PersistMode;
+import com.revrobotics.spark.SparkBase.ResetMode;
+import com.revrobotics.spark.SparkClosedLoopController;
+import com.revrobotics.spark.config.SparkBaseConfig;
+import edu.wpi.first.units.Measure;
+import edu.wpi.first.units.PerUnit;
+import edu.wpi.first.units.TimeUnit;
+import edu.wpi.first.units.Unit;
+import frc.robot.molib.encoder.MoEncoder;
+import frc.robot.utils.MoUtils;
+
+public class MoSparkMaxPID<Dim extends Unit, VDim extends PerUnit<Dim, TimeUnit>> {
+    protected final Type type;
+    protected final SparkBase motorController;
+    protected final ClosedLoopSlot pidSlot;
+    protected final SparkClosedLoopController pidController;
+
+    protected final MoEncoder<Dim, VDim> internalEncoder;
+
+    /**
+     * The last position or velocity setpoint measured in internal encoder units.
+     */
+    protected double lastSetpoint;
+
+    /**
+     * Constructs a MoSparkMaxPID
+     * <p>
+     * Note: the controller's internal encoder should be scaled to return the mechanism's position in units of rotation.
+     * <p>
+     * Note: we need the MoEncoder because it is solely responsible for keeping track of the encoder's internal units,
+     * which are needed to calculate the units for the setpoints.
+     *
+     * @param type the type of PID controller
+     * @param controller the motor controller
+     * @param pidSlot the slot in which to save the PID constants
+     */
+    public MoSparkMaxPID(
+            Type type, SparkBase controller, ClosedLoopSlot pidSlot, MoEncoder<Dim, VDim> internalEncoder) {
+        this.type = type;
+        this.motorController = controller;
+        this.pidSlot = pidSlot;
+        this.pidController = motorController.getClosedLoopController();
+        this.internalEncoder = internalEncoder;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public ClosedLoopSlot getPidSlot() {
+        return pidSlot;
+    }
+
+    public void setP(double kP) {
+        SparkBaseConfig config = MoUtils.getSparkConfig(motorController);
+        config.closedLoop.p(kP, pidSlot);
+        motorController.configure(config, ResetMode.kNoResetSafeParameters, PersistMode.kNoPersistParameters);
+    }
+
+    public void setI(double kI) {
+        SparkBaseConfig config = MoUtils.getSparkConfig(motorController);
+        config.closedLoop.i(kI, pidSlot);
+        motorController.configure(config, ResetMode.kNoResetSafeParameters, PersistMode.kNoPersistParameters);
+    }
+
+    public void setD(double kD) {
+        SparkBaseConfig config = MoUtils.getSparkConfig(motorController);
+        config.closedLoop.d(kD, pidSlot);
+        motorController.configure(config, ResetMode.kNoResetSafeParameters, PersistMode.kNoPersistParameters);
+    }
+
+    public void setFF(double kFF) {
+        SparkBaseConfig config = MoUtils.getSparkConfig(motorController);
+        config.closedLoop.velocityFF(kFF, pidSlot);
+        motorController.configure(config, ResetMode.kNoResetSafeParameters, PersistMode.kNoPersistParameters);
+    }
+
+    public void setIZone(double iZone) {
+        SparkBaseConfig config = MoUtils.getSparkConfig(motorController);
+        config.closedLoop.iZone(iZone, pidSlot);
+        motorController.configure(config, ResetMode.kNoResetSafeParameters, PersistMode.kNoPersistParameters);
+    }
+
+    public double getLastOutput() {
+        return this.motorController.get();
+    }
+
+    /**
+     * Get the last position or velocity reference set on this PID controller, measured in internal encoder units.
+     * @return The last setpoint of this controller
+     */
+    public double getSetpoint() {
+        return lastSetpoint;
+    }
+
+    /**
+     * Get the last position or velocity measurement of the mechanism controlled by this PID controller, measured in
+     * internal encoder units.
+     * @return The last measurement of the mechanism under control
+     */
+    public double getLastMeasurement() {
+        switch (this.type) {
+            case POSITION:
+            case SMARTMOTION:
+                return internalEncoder.getPositionInEncoderUnits();
+            case VELOCITY:
+            case SMARTVELOCITY:
+                return internalEncoder.getVelocityInEncoderUnits();
+        }
+
+        return 0;
+    }
+
+    public void setPositionReference(Measure<Dim> position) {
+        if (this.type != Type.POSITION && this.type != Type.SMARTMOTION) {
+            throw new UnsupportedOperationException(
+                    String.format("Cannot set position on PID controller of type %s", this.type.name()));
+        }
+        double value = position.in(internalEncoder.getInternalEncoderUnits());
+        pidController.setReference(value, this.type.innerType, pidSlot);
+        lastSetpoint = value;
+    }
+
+    public void setVelocityReference(Measure<VDim> velocity) {
+        if (this.type != Type.VELOCITY && this.type != Type.SMARTVELOCITY) {
+            throw new UnsupportedOperationException(
+                    String.format("Cannot set velocity on PID controller of type %s", this.type.name()));
+        }
+        double value = velocity.in(internalEncoder.getInternalEncoderVelocityUnits());
+        pidController.setReference(value, this.type.innerType, pidSlot);
+        lastSetpoint = value;
+    }
+
+    public enum Type {
+        POSITION(SparkBase.ControlType.kPosition),
+        SMARTMOTION(SparkBase.ControlType.kMAXMotionPositionControl),
+        VELOCITY(SparkBase.ControlType.kVelocity),
+        SMARTVELOCITY(SparkBase.ControlType.kMAXMotionVelocityControl);
+
+        public final SparkBase.ControlType innerType;
+
+        private Type(SparkBase.ControlType innerType) {
+            this.innerType = innerType;
+        }
+    }
+}

--- a/src/main/java/frc/robot/molib/pid/MoTalonFxPID.java
+++ b/src/main/java/frc/robot/molib/pid/MoTalonFxPID.java
@@ -1,0 +1,145 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.molib.pid;
+
+import com.ctre.phoenix6.configs.Slot0Configs;
+import com.ctre.phoenix6.controls.ControlRequest;
+import com.ctre.phoenix6.controls.MotionMagicVoltage;
+import com.ctre.phoenix6.controls.PositionVoltage;
+import com.ctre.phoenix6.controls.VelocityVoltage;
+import com.ctre.phoenix6.hardware.TalonFX;
+import edu.wpi.first.units.Measure;
+import edu.wpi.first.units.PerUnit;
+import edu.wpi.first.units.TimeUnit;
+import edu.wpi.first.units.Unit;
+import edu.wpi.first.wpilibj.DriverStation;
+import frc.robot.molib.encoder.TalonFxEncoder;
+import java.util.function.Function;
+
+public class MoTalonFxPID<Dim extends Unit, VDim extends PerUnit<Dim, TimeUnit>> {
+    private final Type type;
+    private final TalonFX motorController;
+    private final Slot0Configs slotPIDConfigs = new Slot0Configs();
+    private double lastReference;
+
+    private Dim internalEncoderUnits;
+    protected final VDim internalEncoderVelocity;
+
+    @SuppressWarnings("unchecked")
+    public MoTalonFxPID(Type type, TalonFX controller, Dim internalEncoderUnits) {
+        this.type = type;
+        this.motorController = controller;
+
+        // Load the motor controller's Slot 0 PID values into slotPIDConfigs
+        this.motorController.getConfigurator().refresh(slotPIDConfigs);
+
+        this.internalEncoderUnits = internalEncoderUnits;
+        this.internalEncoderVelocity = (VDim) internalEncoderUnits.per(TalonFxEncoder.VELOCITY_BASE_UNIT);
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public Slot0Configs getConfigs() {
+        return slotPIDConfigs;
+    }
+
+    public void applyConfigs() {
+        motorController.getConfigurator().apply(slotPIDConfigs);
+    }
+
+    public void setP(double kP) {
+        slotPIDConfigs.kP = kP;
+        applyConfigs();
+    }
+
+    public void setI(double kI) {
+        slotPIDConfigs.kI = kI;
+        applyConfigs();
+    }
+
+    public void setD(double kD) {
+        slotPIDConfigs.kD = kD;
+        applyConfigs();
+    }
+
+    public void setFF(double kFF) {
+        slotPIDConfigs.kV = kFF;
+        applyConfigs();
+    }
+
+    public void setIZone(double iZone) {
+        if (iZone != 0) {
+            DriverStation.reportError("Cannot set iZone on TalonFx, it is not supported by the Phoenix API", true);
+        }
+    }
+
+    public double getLastOutput() {
+        return this.motorController.getBridgeOutput().getValueAsDouble();
+    }
+
+    public double getSetpoint() {
+        return this.lastReference;
+    }
+
+    public double getLastMeasurement() {
+        switch (this.type) {
+            case POSITION:
+            case SMARTMOTION:
+                return this.motorController.getPosition().getValueAsDouble();
+            case VELOCITY:
+                return this.motorController.getVelocity().getValueAsDouble();
+        }
+
+        return 0;
+    }
+
+    /**
+     * Set the reference of the PID controller. The units of value depend on the current type of the controller.
+     * For position controllers (Type.POSITION or Type.SMARTMOTION), value is measured in internalEncoderUnits.
+     * For velocity controllers (Type.VELOCITY or Type.SMARTVELOCITY), value is measured in internalEncoderUnits per second.
+     * <p>
+     * @deprecated Use {@link #setPositionReference(Measure)} or {@link #setVelocityReference(Measure)}
+     */
+    @Deprecated(forRemoval = false)
+    public void setReference(double value) {
+        this.motorController.setControl(this.type.control.apply(value));
+        this.lastReference = value;
+    }
+
+    public void setPositionReference(Measure<Dim> position) {
+        if (this.type != Type.POSITION && this.type != Type.SMARTMOTION) {
+            throw new UnsupportedOperationException(
+                    String.format("Cannot set position on PID controller of type %s", this.type.name()));
+        }
+        double value = position.in(internalEncoderUnits);
+        this.motorController.setControl(this.type.control.apply(value));
+        lastReference = value;
+    }
+
+    public void setVelocityReference(Measure<VDim> velocity) {
+        if (this.type != Type.VELOCITY) {
+            throw new UnsupportedOperationException(
+                    String.format("Cannot set velocity on PID controller of type %s", this.type.name()));
+        }
+
+        double value = velocity.in(internalEncoderVelocity);
+        this.motorController.setControl(this.type.control.apply(value));
+        lastReference = value;
+    }
+
+    public enum Type {
+        POSITION(v -> new PositionVoltage(v)),
+        SMARTMOTION(v -> new MotionMagicVoltage(v)),
+        VELOCITY(v -> new VelocityVoltage(v));
+
+        public final Function<Double, ControlRequest> control;
+
+        private Type(Function<Double, ControlRequest> control) {
+            this.control = control;
+        }
+    }
+}

--- a/src/main/java/frc/robot/molib/prefs/AngleUnitPref.java
+++ b/src/main/java/frc/robot/molib/prefs/AngleUnitPref.java
@@ -1,0 +1,14 @@
+package frc.robot.molib.prefs;
+
+import edu.wpi.first.units.AngleUnit;
+import edu.wpi.first.units.measure.Angle;
+
+public class AngleUnitPref extends UnitPref<AngleUnit> {
+    public AngleUnitPref(String key, AngleUnit storeUnits, Angle defaultValue) {
+        super(key, storeUnits, defaultValue);
+    }
+
+    public Angle get() {
+        return (Angle) super.get();
+    }
+}

--- a/src/main/java/frc/robot/molib/prefs/AngularVelocityUnitPref.java
+++ b/src/main/java/frc/robot/molib/prefs/AngularVelocityUnitPref.java
@@ -1,0 +1,14 @@
+package frc.robot.molib.prefs;
+
+import edu.wpi.first.units.AngularVelocityUnit;
+import edu.wpi.first.units.measure.AngularVelocity;
+
+public class AngularVelocityUnitPref extends UnitPref<AngularVelocityUnit> {
+    public AngularVelocityUnitPref(String key, AngularVelocityUnit storeUnits, AngularVelocity defaultValue) {
+        super(key, storeUnits, defaultValue);
+    }
+
+    public AngularVelocity get() {
+        return (AngularVelocity) super.get();
+    }
+}

--- a/src/main/java/frc/robot/molib/prefs/DistanceUnitPref.java
+++ b/src/main/java/frc/robot/molib/prefs/DistanceUnitPref.java
@@ -1,0 +1,14 @@
+package frc.robot.molib.prefs;
+
+import edu.wpi.first.units.DistanceUnit;
+import edu.wpi.first.units.measure.Distance;
+
+public class DistanceUnitPref extends UnitPref<DistanceUnit> {
+    public DistanceUnitPref(String key, DistanceUnit storeUnits, Distance defaultValue) {
+        super(key, storeUnits, defaultValue);
+    }
+
+    public Distance get() {
+        return (Distance) super.get();
+    }
+}

--- a/src/main/java/frc/robot/molib/prefs/LinearVelocityUnitPref.java
+++ b/src/main/java/frc/robot/molib/prefs/LinearVelocityUnitPref.java
@@ -1,0 +1,14 @@
+package frc.robot.molib.prefs;
+
+import edu.wpi.first.units.LinearVelocityUnit;
+import edu.wpi.first.units.measure.LinearVelocity;
+
+public class LinearVelocityUnitPref extends UnitPref<LinearVelocityUnit> {
+    public LinearVelocityUnitPref(String key, LinearVelocityUnit storeUnits, LinearVelocity defaultValue) {
+        super(key, storeUnits, defaultValue);
+    }
+
+    public LinearVelocity get() {
+        return (LinearVelocity) super.get();
+    }
+}

--- a/src/main/java/frc/robot/molib/prefs/MoPrefs.java
+++ b/src/main/java/frc/robot/molib/prefs/MoPrefs.java
@@ -1,0 +1,156 @@
+package frc.robot.molib.prefs;
+
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.NetworkTableValue;
+import edu.wpi.first.networktables.StringPublisher;
+import edu.wpi.first.networktables.Topic;
+import edu.wpi.first.units.AngleUnit;
+import edu.wpi.first.units.CurrentUnit;
+import edu.wpi.first.units.DimensionlessUnit;
+import edu.wpi.first.units.DistanceUnit;
+import edu.wpi.first.units.Measure;
+import edu.wpi.first.units.PerUnit;
+import edu.wpi.first.units.TimeUnit;
+import edu.wpi.first.units.Units;
+import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.Distance;
+import edu.wpi.first.units.measure.LinearVelocity;
+import frc.robot.molib.MoUnits;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.Set;
+
+/** Robot preferences, accessible through Shuffleboard */
+public class MoPrefs {
+
+    public static final UnitPref<PerUnit<DimensionlessUnit, AngleUnit>> swerveRotScale =
+            encoderTicksPerRotationPref("SWRV ROT Scale", MoUnits.EncoderTicksPerRotation.ofNative(12.8));
+    public static final UnitPref<PerUnit<DimensionlessUnit, DistanceUnit>> swerveDistScale =
+            encoderTicksPerMeterPref("SWRV DIST Scale", MoUnits.EncoderTicksPerMeter.ofNative(21.49));
+    public static final AngleUnitPref swerveFLZero = rotationsPref("SWRV Zero FL", Units.Rotations.of(0.186));
+    public static final AngleUnitPref swerveFRZero = rotationsPref("SWRV Zero FR", Units.Rotations.of(0.48));
+    public static final AngleUnitPref swerveRLZero = rotationsPref("SWRV Zero RL", Units.Rotations.of(0.895));
+    public static final AngleUnitPref swerveRRZero = rotationsPref("SWRV Zero RR", Units.Rotations.of(0.968));
+
+    public static final LinearVelocityUnitPref swerveMaxLinearSpeed =
+            metersPerSecPref("SWRV Max Linear Speed", Units.MetersPerSecond.of(5));
+    public static final AngularVelocityUnitPref swerveMaxAngularSpeed =
+            rotationsPerSecPref("SWRV Max Angular Speed", Units.RotationsPerSecond.of(1));
+
+    NetworkTable backingTable;
+
+    private static MoPrefs instance;
+    private StringPublisher typePublisher;
+
+    static synchronized MoPrefs getInstance() {
+        if (instance == null) {
+            instance = new MoPrefs();
+        }
+        return instance;
+    }
+
+    public static void cleanUpPrefs() {
+        MoPrefs instance = getInstance();
+
+        HashSet<String> pref_keys = new HashSet<>();
+
+        // Shouldn't remove the special field .type
+        pref_keys.add(".type");
+
+        for (Field f : MoPrefs.class.getFields()) {
+            if (Modifier.isStatic(f.getModifiers())) {
+                Object fo;
+
+                try {
+                    fo = f.get(instance);
+                } catch (IllegalArgumentException | IllegalAccessException e) {
+                    continue;
+                }
+
+                if (fo instanceof Pref fop) {
+                    pref_keys.add(fop.getKey());
+                } else if (fo instanceof UnitPref fop) {
+                    pref_keys.add(fop.getKey());
+                }
+            }
+        }
+
+        Set<String> table_keys = instance.backingTable.getKeys();
+
+        System.out.println("****** Clean up MoPrefs ******");
+        for (String key : table_keys) {
+            if (!pref_keys.contains(key)) {
+                System.out.format("Remove unused pref \"%s\"\n", key);
+
+                Topic topic = instance.backingTable.getTopic(key);
+                topic.setPersistent(false);
+                topic.setRetained(false);
+            }
+        }
+    }
+
+    private MoPrefs() {
+        backingTable = NetworkTableInstance.getDefault().getTable("Preferences");
+        typePublisher = backingTable.getStringTopic(".type").publish();
+        typePublisher.set("RobotPreferences");
+    }
+
+    private static Pref<Boolean> booleanPref(String key, boolean defaultValue) {
+        return new Pref<>(key, defaultValue, NetworkTableValue::getBoolean, NetworkTableEntry::setBoolean);
+    }
+
+    private static Pref<Double> unitlessDoublePref(String key, double defaultValue) {
+        return new Pref<>(key, defaultValue, NetworkTableValue::getDouble, NetworkTableEntry::setDouble);
+    }
+
+    private static AngleUnitPref rotationsPref(String key, Angle defaultValue) {
+        return new AngleUnitPref(key, Units.Rotations, defaultValue);
+    }
+
+    private static AngleUnitPref degreesPref(String key, Angle defaultValue) {
+        return new AngleUnitPref(key, Units.Degrees, defaultValue);
+    }
+
+    private static DistanceUnitPref metersPref(String key, Distance defaultValue) {
+        return new DistanceUnitPref(key, Units.Meters, defaultValue);
+    }
+
+    private static DistanceUnitPref centimetersPref(String key, Distance defaultValue) {
+        return new DistanceUnitPref(key, Units.Centimeters, defaultValue);
+    }
+
+    private static LinearVelocityUnitPref metersPerSecPref(String key, LinearVelocity defaultValue) {
+        return new LinearVelocityUnitPref(key, Units.MetersPerSecond, defaultValue);
+    }
+
+    private static AngularVelocityUnitPref rotationsPerSecPref(String key, AngularVelocity defaultValue) {
+        return new AngularVelocityUnitPref(key, Units.RotationsPerSecond, defaultValue);
+    }
+
+    private static UnitPref<PerUnit<DimensionlessUnit, DistanceUnit>> encoderTicksPerCentimeterPref(
+            String key, Measure<PerUnit<DimensionlessUnit, DistanceUnit>> defaultValue) {
+        return new UnitPref<>(key, MoUnits.EncoderTicksPerCentimeter, defaultValue);
+    }
+
+    private static UnitPref<PerUnit<DimensionlessUnit, DistanceUnit>> encoderTicksPerMeterPref(
+            String key, Measure<PerUnit<DimensionlessUnit, DistanceUnit>> defaultValue) {
+        return new UnitPref<>(key, MoUnits.EncoderTicksPerMeter, defaultValue);
+    }
+
+    private static UnitPref<PerUnit<DimensionlessUnit, AngleUnit>> encoderTicksPerRotationPref(
+            String key, Measure<PerUnit<DimensionlessUnit, AngleUnit>> defaultValue) {
+        return new UnitPref<>(key, MoUnits.EncoderTicksPerRotation, defaultValue);
+    }
+
+    private static UnitPref<TimeUnit> secondsPref(String key, Measure<TimeUnit> defaultValue) {
+        return new UnitPref<>(key, Units.Seconds, defaultValue);
+    }
+
+    private static UnitPref<CurrentUnit> ampsPref(String key, Measure<CurrentUnit> defaultValue) {
+        return new UnitPref<>(key, Units.Amps, defaultValue);
+    }
+}

--- a/src/main/java/frc/robot/molib/prefs/MoPrefs.java
+++ b/src/main/java/frc/robot/molib/prefs/MoPrefs.java
@@ -36,6 +36,11 @@ public class MoPrefs {
     public static final AngleUnitPref swerveRLZero = rotationsPref("SWRV Zero RL", Units.Rotations.of(0.895));
     public static final AngleUnitPref swerveRRZero = rotationsPref("SWRV Zero RR", Units.Rotations.of(0.968));
 
+    /**
+     * The yaw offset between "forward" on the robot and "angle zero" on the gyro
+     */
+    public static final AngleUnitPref navxYawOffset = rotationsPref("NavX Yaw Offset", Units.Rotations.zero());
+
     public static final LinearVelocityUnitPref swerveMaxLinearSpeed =
             metersPerSecPref("SWRV Max Linear Speed", Units.MetersPerSecond.of(5));
     public static final AngularVelocityUnitPref swerveMaxAngularSpeed =

--- a/src/main/java/frc/robot/molib/prefs/MoPrefs.java
+++ b/src/main/java/frc/robot/molib/prefs/MoPrefs.java
@@ -27,6 +27,10 @@ import java.util.Set;
 /** Robot preferences, accessible through Shuffleboard */
 public class MoPrefs {
 
+    public static final Pref<Double> inputDeadzone = unitlessDoublePref("Input Deadzone", 0.05);
+    public static final Pref<Double> inputCurve = unitlessDoublePref("Input Curve", 1.5);
+    public static final Pref<Double> driveRampTime = unitlessDoublePref("Input Ramp Time", 0.1);
+
     public static final UnitPref<PerUnit<DimensionlessUnit, AngleUnit>> swerveRotScale =
             encoderTicksPerRotationPref("SWRV ROT Scale", MoUnits.EncoderTicksPerRotation.ofNative(12.8));
     public static final UnitPref<PerUnit<DimensionlessUnit, DistanceUnit>> swerveDistScale =

--- a/src/main/java/frc/robot/molib/prefs/Pref.java
+++ b/src/main/java/frc/robot/molib/prefs/Pref.java
@@ -1,0 +1,70 @@
+package frc.robot.molib.prefs;
+
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableEvent;
+import edu.wpi.first.networktables.NetworkTableValue;
+import java.util.EnumSet;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class Pref<T> {
+    public final String key;
+    private Function<NetworkTableValue, T> getter;
+    private BiFunction<NetworkTableEntry, T, Boolean> setter;
+
+    private final NetworkTableEntry entry;
+
+    private Consumer<T> subscriber = null;
+
+    public Pref(
+            String key,
+            T defaultValue,
+            Function<NetworkTableValue, T> getter,
+            BiFunction<NetworkTableEntry, T, Boolean> setter) {
+        if (key.contains("/")) {
+            throw new IllegalArgumentException("Pref keys must not contain '/'");
+        }
+
+        this.key = key;
+        this.getter = getter;
+        this.setter = setter;
+
+        this.entry = MoPrefs.getInstance().backingTable.getEntry(key);
+        this.entry.setDefaultValue(defaultValue);
+        this.entry.setPersistent();
+    }
+
+    public T get() {
+        return getter.apply(entry.getValue());
+    }
+
+    public void set(T value) {
+        setter.apply(entry, value);
+    }
+
+    public void subscribe(Consumer<T> consumer) {
+        subscribe(consumer, false);
+    }
+
+    public void subscribe(Consumer<T> consumer, boolean notifyImmediately) {
+        if (subscriber != null) {
+            subscriber = subscriber.andThen(consumer);
+        } else {
+            subscriber = consumer;
+            entry.getInstance()
+                    .addListener(
+                            entry,
+                            EnumSet.of(NetworkTableEvent.Kind.kValueAll),
+                            (e) -> consumer.accept(getter.apply(e.valueData.value)));
+        }
+
+        if (notifyImmediately) {
+            consumer.accept(this.get());
+        }
+    }
+
+    public String getKey() {
+        return key;
+    }
+}

--- a/src/main/java/frc/robot/molib/prefs/UnitPref.java
+++ b/src/main/java/frc/robot/molib/prefs/UnitPref.java
@@ -1,0 +1,49 @@
+package frc.robot.molib.prefs;
+
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableValue;
+import edu.wpi.first.units.Measure;
+import edu.wpi.first.units.MutableMeasure;
+import edu.wpi.first.units.Unit;
+import java.util.function.Consumer;
+
+public class UnitPref<U extends Unit> {
+    private final Pref<Double> basePref;
+    private final U storeUnits;
+
+    private final MutableMeasure<U, ?, ?> currValue;
+
+    public UnitPref(String key, U storeUnits, Measure<U> defaultValue) {
+        String symbol = storeUnits.symbol().replaceAll("/", "_");
+
+        currValue = defaultValue.mutableCopy();
+
+        this.basePref = new Pref<>(
+                String.format("%s (%s)", key, symbol),
+                defaultValue.in(storeUnits),
+                NetworkTableValue::getDouble,
+                NetworkTableEntry::setDouble);
+
+        this.storeUnits = storeUnits;
+    }
+
+    public Measure<U> get() {
+        return currValue.mut_replace(basePref.get(), storeUnits);
+    }
+
+    public void set(Measure<U> value) {
+        basePref.set(value.in(storeUnits));
+    }
+
+    public void subscribe(Consumer<Measure<U>> consumer) {
+        subscribe(consumer, false);
+    }
+
+    public void subscribe(Consumer<Measure<U>> consumer, boolean notifyImmediately) {
+        basePref.subscribe((value) -> consumer.accept(currValue.mut_replace(value, storeUnits)), notifyImmediately);
+    }
+
+    public String getKey() {
+        return basePref.getKey();
+    }
+}

--- a/src/main/java/frc/robot/subsystem/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystem/DriveSubsystem.java
@@ -1,0 +1,193 @@
+package frc.robot.subsystem;
+
+import com.ctre.phoenix6.hardware.TalonFX;
+import com.revrobotics.spark.SparkLowLevel.MotorType;
+import com.revrobotics.spark.SparkMax;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
+import edu.wpi.first.math.kinematics.SwerveModuleState;
+import edu.wpi.first.units.Units;
+import edu.wpi.first.units.measure.Distance;
+import edu.wpi.first.units.measure.MutAngularVelocity;
+import edu.wpi.first.units.measure.MutLinearVelocity;
+import edu.wpi.first.units.measure.Time;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.shuffleboard.BuiltInLayouts;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants;
+import frc.robot.component.SwerveModule;
+import frc.robot.molib.MoShuffleboard;
+import frc.robot.molib.prefs.MoPrefs;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class DriveSubsystem extends SubsystemBase {
+
+    /**
+     * How frequently the absolute encoder will be used to re-zero the relative encoders.
+     */
+    private static final Time RESET_ENCODER_PERIOD = Units.Seconds.of(0.5);
+
+    /**
+     * The distance along one axis, in meters, from the center of the robot to the center of a
+     * swerve module wheel. Since the chassis is square, we don't have to keep track of the X and Y
+     * dimensions separately.
+     * <p>
+     * The robot frame has a side length of 29.5". The mounting holes for the serve modules
+     * are 0.5" inset from the edge of the frame. Per the SDS layout diagram of the MK4 swerve
+     * modules, the length between the mounting holes and the center of the swerve wheel is 2.75".
+     * So, the distance from the center of the robot to the center of a swerve wheel is
+     * 29.5"/2 - 0.5" - 2.75" = 11.5".
+     */
+    public static final Distance SWERVE_WHEEL_OFFSET = Units.Inch.of(11.5);
+
+    private final SwerveModule frontLeft;
+    private final SwerveModule frontRight;
+    private final SwerveModule rearLeft;
+    private final SwerveModule rearRight;
+
+    private final Timer resetEncoderTimer = new Timer();
+
+    public final SwerveDriveKinematics kinematics;
+
+    public DriveSubsystem() {
+        super("Drive");
+
+        this.frontLeft = new SwerveModule(
+                "SWRV FL",
+                new SparkMax(Constants.SWERVE_TURN_LEFT_FRONT.address(), MotorType.kBrushless),
+                new TalonFX(Constants.SWERVE_DRIVE_LEFT_FRONT.address()),
+                MoPrefs.swerveFLZero,
+                MoPrefs.swerveRotScale,
+                MoPrefs.swerveDistScale);
+
+        this.frontRight = new SwerveModule(
+                "SWRV FR",
+                new SparkMax(Constants.SWERVE_TURN_RIGHT_FRONT.address(), MotorType.kBrushless),
+                new TalonFX(Constants.SWERVE_DRIVE_RIGHT_FRONT.address()),
+                MoPrefs.swerveFRZero,
+                MoPrefs.swerveRotScale,
+                MoPrefs.swerveDistScale);
+
+        this.rearLeft = new SwerveModule(
+                "SWRV RL",
+                new SparkMax(Constants.SWERVE_TURN_LEFT_REAR.address(), MotorType.kBrushless),
+                new TalonFX(Constants.SWERVE_DRIVE_LEFT_REAR.address()),
+                MoPrefs.swerveRLZero,
+                MoPrefs.swerveRotScale,
+                MoPrefs.swerveDistScale);
+
+        this.rearRight = new SwerveModule(
+                "SWRV RR",
+                new SparkMax(Constants.SWERVE_TURN_RIGHT_REAR.address(), MotorType.kBrushless),
+                new TalonFX(Constants.SWERVE_DRIVE_RIGHT_REAR.address()),
+                MoPrefs.swerveRRZero,
+                MoPrefs.swerveRotScale,
+                MoPrefs.swerveDistScale);
+
+        resetEncoderTimer.start();
+
+        double offset_meters = SWERVE_WHEEL_OFFSET.in(Units.Meters);
+        Translation2d fl = new Translation2d(offset_meters, offset_meters);
+        Translation2d fr = new Translation2d(offset_meters, -offset_meters);
+        Translation2d rl = new Translation2d(-offset_meters, offset_meters);
+        Translation2d rr = new Translation2d(-offset_meters, -offset_meters);
+
+        this.kinematics = new SwerveDriveKinematics(fl, fr, rl, rr);
+
+        MoShuffleboard.getInstance().ifPresent(board -> {
+            forEachSwerveModule((module) -> {
+                var group = board.driveTab
+                        .getLayout(module.getKey(), BuiltInLayouts.kList)
+                        .withSize(2, 2)
+                        .withProperties(Map.of("Label Position", "RIGHT"));
+                group.addDouble(
+                        "Drive Position (raw)",
+                        () -> module.driveMotor.getRotorPosition().getValueAsDouble());
+                group.addDouble(
+                        "Drive Position (m)",
+                        () -> module.distEncoder.getPosition().in(Units.Meters));
+                group.addDouble(
+                        "Drive Velocity (m_s)",
+                        () -> module.distEncoder.getVelocity().in(Units.MetersPerSecond));
+                group.addDouble(
+                        "Turn Relative (R)",
+                        () -> module.relativeEncoder.getPosition().in(Units.Rotations));
+                group.addDouble(
+                        "Turn Absolute (R)",
+                        () -> module.absoluteEncoder.getPosition().in(Units.Rotations));
+            });
+
+            board.driveTab.add(this);
+        });
+    }
+
+    private void forEachSwerveModule(Consumer<SwerveModule> forBody) {
+        forBody.accept(frontLeft);
+        forBody.accept(frontRight);
+        forBody.accept(rearLeft);
+        forBody.accept(rearRight);
+    }
+
+    /**
+     * Robot-oriented cartesian drive
+     */
+    public void driveCartesian(double fwdRequest, double leftRequest, double turnRequest) {
+        this.driveCartesian(fwdRequest, leftRequest, turnRequest, new Rotation2d());
+    }
+
+    private MutLinearVelocity mutFwdRequest = Units.MetersPerSecond.mutable(0);
+    private MutLinearVelocity mutLeftRequest = Units.MetersPerSecond.mutable(0);
+    private MutAngularVelocity mutTurnRequest = Units.RotationsPerSecond.mutable(0);
+
+    /**
+     * Field-oriented cartesian drive
+     */
+    public void driveCartesian(
+            double fwdRequest, double leftRequest, double turnRequest, Rotation2d fieldOrientedDriveAngle) {
+        var maxLinearSpeed = MoPrefs.swerveMaxLinearSpeed.get();
+        var maxAngularSpeed = MoPrefs.swerveMaxAngularSpeed.get();
+
+        mutFwdRequest.mut_replace(maxLinearSpeed);
+        mutLeftRequest.mut_replace(maxLinearSpeed);
+        mutTurnRequest.mut_replace(maxAngularSpeed);
+
+        mutFwdRequest.mut_times(fwdRequest);
+        mutLeftRequest.mut_times(leftRequest);
+        mutTurnRequest.mut_times(turnRequest);
+
+        ChassisSpeeds speeds = ChassisSpeeds.fromFieldRelativeSpeeds(
+                mutFwdRequest, mutLeftRequest, mutTurnRequest, fieldOrientedDriveAngle);
+
+        driveRobotRelativeSpeeds(speeds);
+    }
+
+    public void driveRobotRelativeSpeeds(ChassisSpeeds speeds) {
+        driveSwerveStates(kinematics.toSwerveModuleStates(speeds));
+    }
+
+    public void driveSwerveStates(SwerveModuleState[] states) {
+        SwerveDriveKinematics.desaturateWheelSpeeds(states, MoPrefs.swerveMaxLinearSpeed.get());
+
+        frontLeft.drive(states[0]);
+        frontRight.drive(states[1]);
+        rearLeft.drive(states[2]);
+        rearRight.drive(states[3]);
+    }
+
+    public void resetRelativeEncoders() {
+        frontLeft.setRelativePosition();
+        frontRight.setRelativePosition();
+        rearLeft.setRelativePosition();
+        rearRight.setRelativePosition();
+    }
+
+    @Override
+    public void periodic() {
+        if (resetEncoderTimer.advanceIfElapsed(RESET_ENCODER_PERIOD.in(Units.Seconds))) {
+            resetRelativeEncoders();
+        }
+    }
+}

--- a/src/main/java/frc/robot/subsystem/PositioningSubsystem.java
+++ b/src/main/java/frc/robot/subsystem/PositioningSubsystem.java
@@ -1,0 +1,27 @@
+package frc.robot.subsystem;
+
+import com.studica.frc.AHRS;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.molib.prefs.MoPrefs;
+
+public class PositioningSubsystem extends SubsystemBase {
+
+    private final AHRS gyro;
+
+    private Rotation2d fieldOrientedFwd;
+
+    public PositioningSubsystem(AHRS gyro) {
+        this.gyro = gyro;
+
+        resetFieldOrientedFwd();
+    }
+
+    public Rotation2d getFieldOrientedDriveHeading() {
+        return gyro.getRotation2d().minus(fieldOrientedFwd);
+    }
+
+    public void resetFieldOrientedFwd() {
+        this.fieldOrientedFwd = gyro.getRotation2d().plus(new Rotation2d(MoPrefs.navxYawOffset.get()));
+    }
+}

--- a/src/main/java/frc/robot/utils/MoUtils.java
+++ b/src/main/java/frc/robot/utils/MoUtils.java
@@ -1,0 +1,25 @@
+package frc.robot.utils;
+
+import com.revrobotics.spark.SparkBase;
+import com.revrobotics.spark.SparkFlex;
+import com.revrobotics.spark.SparkMax;
+import com.revrobotics.spark.config.SparkBaseConfig;
+import com.revrobotics.spark.config.SparkFlexConfig;
+import com.revrobotics.spark.config.SparkMaxConfig;
+
+public class MoUtils {
+
+    public static SparkBaseConfig getSparkConfig(SparkBase spark) {
+        if (spark instanceof SparkMax) {
+            return new SparkMaxConfig();
+        } else if (spark instanceof SparkFlex) {
+            return new SparkFlexConfig();
+        } else {
+            throw new IllegalArgumentException("Unsupported SparkBase subclass");
+        }
+    }
+
+    private MoUtils() {
+        throw new UnsupportedOperationException("MoUtils is a static class");
+    }
+}

--- a/src/main/java/frc/robot/utils/MoUtils.java
+++ b/src/main/java/frc/robot/utils/MoUtils.java
@@ -19,6 +19,14 @@ public class MoUtils {
         }
     }
 
+    public static double curve(double val, double curve) {
+        if (curve == 0) {
+            return val;
+        }
+
+        return Math.signum(val) * Math.pow(Math.abs(val), curve);
+    }
+
     private MoUtils() {
         throw new UnsupportedOperationException("MoUtils is a static class");
     }

--- a/src/main/java/frc/robot/utils/TunerUtils.java
+++ b/src/main/java/frc/robot/utils/TunerUtils.java
@@ -1,0 +1,72 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.utils;
+
+import com.momentum4999.motune.PIDTuner;
+import com.momentum4999.motune.PIDTunerBuilder;
+import edu.wpi.first.units.PerUnit;
+import edu.wpi.first.units.TimeUnit;
+import edu.wpi.first.units.Unit;
+import frc.robot.Constants;
+import frc.robot.molib.pid.MoSparkMaxPID;
+import frc.robot.molib.pid.MoTalonFxPID;
+
+public class TunerUtils {
+
+    private static <Dim extends Unit, VDim extends PerUnit<Dim, TimeUnit>> PIDTunerBuilder moSparkBase(
+            MoSparkMaxPID<Dim, VDim> sparkMax, String controllerName) {
+        PIDTunerBuilder builder = PIDTuner.builder(controllerName)
+                .withDataStoreFile(Constants.DATA_STORE_FILE)
+                .withP(sparkMax::setP)
+                .withI(sparkMax::setI)
+                .withD(sparkMax::setD)
+                .withIZone(sparkMax::setIZone)
+                .withSetpoint(sparkMax::getSetpoint)
+                .withMeasurement(sparkMax::getLastMeasurement);
+
+        if (sparkMax.getType() == MoSparkMaxPID.Type.SMARTMOTION) {
+            builder = builder.withProperty(
+                            "maxVel",
+                            (v) -> sparkMax.setConfigOption(
+                                    c -> c.closedLoop.maxMotion.maxVelocity(v, sparkMax.getPidSlot())))
+                    .withProperty(
+                            "maxAccel",
+                            (a) -> sparkMax.setConfigOption(
+                                    c -> c.closedLoop.maxMotion.maxAcceleration(a, sparkMax.getPidSlot())))
+                    .withProperty(
+                            "allowedError",
+                            (e) -> sparkMax.setConfigOption(c -> c.closedLoop.maxMotion.allowedClosedLoopError(e)));
+        } else if (sparkMax.getType() == MoSparkMaxPID.Type.SMARTVELOCITY) {
+            builder = builder.withProperty(
+                            "maxAccel",
+                            (a) -> sparkMax.setConfigOption(
+                                    c -> c.closedLoop.maxMotion.maxAcceleration(a, sparkMax.getPidSlot())))
+                    .withProperty(
+                            "allowedError",
+                            (e) -> sparkMax.setConfigOption(c -> c.closedLoop.maxMotion.allowedClosedLoopError(e)));
+        }
+
+        return builder;
+    }
+
+    public static <Dim extends Unit, VDim extends PerUnit<Dim, TimeUnit>> PIDTuner forMoSparkMax(
+            MoSparkMaxPID<Dim, VDim> sparkMax, String controllerName) {
+        return moSparkBase(sparkMax, controllerName).withFF(sparkMax::setFF).safeBuild();
+    }
+
+    public static <Dim extends Unit, VDim extends PerUnit<Dim, TimeUnit>> PIDTuner forMoTalonFx(
+            MoTalonFxPID<Dim, VDim> talon, String controllerName) {
+        return PIDTuner.builder(controllerName)
+                .withDataStoreFile(Constants.DATA_STORE_FILE)
+                .withP(talon::setP)
+                .withI(talon::setI)
+                .withD(talon::setD)
+                .withFF(talon::setFF)
+                .withIZone(talon::setIZone)
+                .withSetpoint(talon::getSetpoint)
+                .withMeasurement(talon::getLastMeasurement)
+                .safeBuild();
+    }
+}

--- a/src/main/java/frc/robot/utils/Vec2.java
+++ b/src/main/java/frc/robot/utils/Vec2.java
@@ -1,0 +1,50 @@
+package frc.robot.utils;
+
+public class Vec2 {
+    private double x;
+    private double y;
+
+    public Vec2(double x, double y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public double getX() {
+        return x;
+    }
+
+    public double getY() {
+        return y;
+    }
+
+    public double magnitude() {
+        return Math.sqrt((x * x) + (y * y));
+    }
+
+    /**
+     * Mutates this Vec2 into a unit vector. Returns the original magnitude.
+     */
+    public double normalize() {
+        double mag = magnitude();
+        if (mag >= 1e-6) {
+            this.x /= mag;
+            this.y /= mag;
+        }
+        return mag;
+    }
+
+    public void scale(double scale) {
+        this.x *= scale;
+        this.y *= scale;
+    }
+
+    public void update(double x, double y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public void update(Vec2 toCopy) {
+        this.x = toCopy.x;
+        this.y = toCopy.y;
+    }
+}

--- a/vendordeps/Phoenix6-frc2025-latest.json
+++ b/vendordeps/Phoenix6-frc2025-latest.json
@@ -1,0 +1,389 @@
+{
+    "fileName": "Phoenix6-frc2025-latest.json",
+    "name": "CTRE-Phoenix (v6)",
+    "version": "25.1.0",
+    "frcYear": "2025",
+    "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
+    "mavenUrls": [
+        "https://maven.ctr-electronics.com/release/"
+    ],
+    "jsonUrl": "https://maven.ctr-electronics.com/release/com/ctre/phoenix6/latest/Phoenix6-frc2025-latest.json",
+    "conflictsWith": [
+        {
+            "uuid": "e7900d8d-826f-4dca-a1ff-182f658e98af",
+            "errorMessage": "Users can not have both the replay and regular Phoenix 6 vendordeps in their robot program.",
+            "offlineFileName": "Phoenix6-replay-frc2025-latest.json"
+        }
+    ],
+    "javaDependencies": [
+        {
+            "groupId": "com.ctre.phoenix6",
+            "artifactId": "wpiapi-java",
+            "version": "25.1.0"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "com.ctre.phoenix6",
+            "artifactId": "api-cpp",
+            "version": "25.1.0",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "linuxathena"
+            ],
+            "simMode": "hwsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6",
+            "artifactId": "tools",
+            "version": "25.1.0",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "linuxathena"
+            ],
+            "simMode": "hwsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "api-cpp-sim",
+            "version": "25.1.0",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "tools-sim",
+            "version": "25.1.0",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "simTalonSRX",
+            "version": "25.1.0",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "simVictorSPX",
+            "version": "25.1.0",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "simPigeonIMU",
+            "version": "25.1.0",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "simCANCoder",
+            "version": "25.1.0",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "simProTalonFX",
+            "version": "25.1.0",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "simProCANcoder",
+            "version": "25.1.0",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "simProPigeon2",
+            "version": "25.1.0",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "simProCANrange",
+            "version": "25.1.0",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "com.ctre.phoenix6",
+            "artifactId": "wpiapi-cpp",
+            "version": "25.1.0",
+            "libName": "CTRE_Phoenix6_WPI",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "linuxathena"
+            ],
+            "simMode": "hwsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6",
+            "artifactId": "tools",
+            "version": "25.1.0",
+            "libName": "CTRE_PhoenixTools",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "linuxathena"
+            ],
+            "simMode": "hwsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "wpiapi-cpp-sim",
+            "version": "25.1.0",
+            "libName": "CTRE_Phoenix6_WPISim",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "tools-sim",
+            "version": "25.1.0",
+            "libName": "CTRE_PhoenixTools_Sim",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "simTalonSRX",
+            "version": "25.1.0",
+            "libName": "CTRE_SimTalonSRX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "simVictorSPX",
+            "version": "25.1.0",
+            "libName": "CTRE_SimVictorSPX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "simPigeonIMU",
+            "version": "25.1.0",
+            "libName": "CTRE_SimPigeonIMU",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "simCANCoder",
+            "version": "25.1.0",
+            "libName": "CTRE_SimCANCoder",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "simProTalonFX",
+            "version": "25.1.0",
+            "libName": "CTRE_SimProTalonFX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "simProCANcoder",
+            "version": "25.1.0",
+            "libName": "CTRE_SimProCANcoder",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "simProPigeon2",
+            "version": "25.1.0",
+            "libName": "CTRE_SimProPigeon2",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        },
+        {
+            "groupId": "com.ctre.phoenix6.sim",
+            "artifactId": "simProCANrange",
+            "version": "25.1.0",
+            "libName": "CTRE_SimProCANrange",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "linuxarm64",
+                "osxuniversal"
+            ],
+            "simMode": "swsim"
+        }
+    ]
+}

--- a/vendordeps/REVLib.json
+++ b/vendordeps/REVLib.json
@@ -1,0 +1,74 @@
+{
+    "fileName": "REVLib.json",
+    "name": "REVLib",
+    "version": "2025.0.0",
+    "frcYear": "2025",
+    "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
+    "mavenUrls": [
+        "https://maven.revrobotics.com/"
+    ],
+    "jsonUrl": "https://software-metadata.revrobotics.com/REVLib-2025.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-java",
+            "version": "2025.0.0"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-driver",
+            "version": "2025.0.0",
+            "skipInvalidPlatforms": true,
+            "isJar": false,
+            "validPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-cpp",
+            "version": "2025.0.0",
+            "libName": "REVLib",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        },
+        {
+            "groupId": "com.revrobotics.frc",
+            "artifactId": "REVLib-driver",
+            "version": "2025.0.0",
+            "libName": "REVLibDriver",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        }
+    ]
+}

--- a/vendordeps/Studica-2025.0.0.json
+++ b/vendordeps/Studica-2025.0.0.json
@@ -1,0 +1,71 @@
+{
+    "fileName": "Studica-2025.0.0.json",
+    "name": "Studica",
+    "version": "2025.0.0",
+    "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
+    "frcYear": "2025",
+    "mavenUrls": [
+        "https://dev.studica.com/maven/release/2025/"
+    ],
+    "jsonUrl": "https://dev.studica.com/releases/2025/Studica-2025.0.0.json",
+    "cppDependencies": [
+        {
+            "artifactId": "Studica-cpp",
+            "binaryPlatforms": [
+                "linuxathena",
+                "linuxarm32",
+                "linuxarm64",
+                "linuxx86-64",
+                "osxuniversal",
+                "windowsx86-64"
+            ],
+            "groupId": "com.studica.frc",
+            "headerClassifier": "headers",
+            "libName": "Studica",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "version": "2025.0.0"
+        },
+        {
+            "artifactId": "Studica-driver",
+            "binaryPlatforms": [
+                "linuxathena",
+                "linuxarm32",
+                "linuxarm64",
+                "linuxx86-64",
+                "osxuniversal",
+                "windowsx86-64"
+            ],
+            "groupId": "com.studica.frc",
+            "headerClassifier": "headers",
+            "libName": "StudicaDriver",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "version": "2025.0.0"
+        }
+    ],
+    "javaDependencies": [
+        {
+            "artifactId": "Studica-java",
+            "groupId": "com.studica.frc",
+            "version": "2025.0.0"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "artifactId": "Studica-driver",
+            "groupId": "com.studica.frc",
+            "isJar": false,
+            "skipInvalidPlatforms": true,
+            "validPlatforms": [
+                "linuxathena",
+                "linuxarm32",
+                "linuxarm64",
+                "linuxx86-64",
+                "osxuniversal",
+                "windowsx86-64"
+            ],
+            "version": "2025.0.0"
+        }
+    ]
+}

--- a/vendordeps/momentum-tuners-core.json
+++ b/vendordeps/momentum-tuners-core.json
@@ -1,0 +1,20 @@
+{
+    "fileName": "momentum-tuners-core.json",
+    "name": "Momentum Tuners Core",
+    "version": "0.2.1",
+    "uuid": "f4cf90fb-86a6-4fde-825d-c375bcdac45f",
+    "frcYear": 2025,
+    "mavenUrls": [
+        "https://raw.githubusercontent.com/momentumfrc/Momentum-Tools/master/mvn-repo"
+    ],
+    "jsonUrl": "https://raw.githubusercontent.com/momentumfrc/Momentum-Tools/master/json/momentum-tuners/momentum-tuners-core.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.momentum4999.motune",
+            "artifactId": "motune-core",
+            "version": "0.2.1"
+        }
+    ],
+    "jniDependencies": [],
+    "cppDependencies": []
+}


### PR DESCRIPTION
This PR implements the base code for teleoperated field-oriented swerve control.

Of course, this means I had to bring over all the supporting infrastructure from the 2024 repo.

This includes:
- Vendordeps for CTRE, Rev, Studica (Navx), and MoTune
- MoEncoders: unit-aware encoder wrapper class
- MoPID: unit-aware PID controller wrapper classes for Sparks and Talons
- MoPrefs: unit-aware persistent key-value store for robot preferences
- MoShuffleboard: central store for ShuffleboardTab instances
- Simple PositioningSubsystem: just holds the navx for field-oriented driving

Since the units library was rethought for 2025, the `MoEncoder`, `MoPid`, and `MoPrefs` classes took a lot of rewriting to get working. The new implementations have a lot of verbose subclasses (e.g. UnitPref had to be split into AngleUnitPref, AngularVelocityUnitPref, DistanceUnitPref, LinearVelocityUnitPref), but this was required due to wpilib's new approach of also using a bunch of subclasses to represent different measures (i.e. instead of using one `Measure<>` generic everywhere, it now has specific classes for `Angle`, `AngularVelocity`, `Distance`, `LinearVelocity`, etc.). The bulk of the logic is still kept in a generic superclass, but the dimension-specific subclasses handle casting into these new specific measure subclasses as needed.